### PR TITLE
Search result country buttons

### DIFF
--- a/country-stats-app/src/Pages/SearchPage.jsx
+++ b/country-stats-app/src/Pages/SearchPage.jsx
@@ -1,10 +1,18 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { SearchBox } from '../SearchBox';
 
 export function SearchPage() {
+    const [countryStats, setCountryStats] = useState(null);
+    const handleDataChange = (newData) => {
+        setCountryStats(newData);
+      };
+
     return (
         <>
-            <h1>Search Page components go here</h1>
+            <SearchBox onDataFetched={handleDataChange} />
             <Link to="/info">Go to Info Page</Link>
+            <p>{countryStats ? <pre>{JSON.stringify(countryStats, null, 2)}</pre> : 'No data yet.'}</p>
         </>
     );
 }

--- a/country-stats-app/src/Pages/SearchPage.jsx
+++ b/country-stats-app/src/Pages/SearchPage.jsx
@@ -1,18 +1,31 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { SearchBox } from '../SearchBox';
 
 export function SearchPage() {
     const [countryStats, setCountryStats] = useState(null);
+    const navigate = useNavigate();
+
     const handleDataChange = (newData) => {
         setCountryStats(newData);
       };
 
+    const handleCountryClick = (index) => {
+        navigate('/info', {state:{country: countryStats[index]}})
+    }
+
     return (
         <>
             <SearchBox onDataFetched={handleDataChange} />
-            <Link to="/info">Go to Info Page</Link>
-            <p>{countryStats ? <pre>{JSON.stringify(countryStats, null, 2)}</pre> : 'No data yet.'}</p>
+            {countryStats ? (
+                <>
+                    {countryStats.map((country, index) => (
+                        <button onClick={() => handleCountryClick(index)} key={index}>{country.name.common}</button>
+                    ))}
+                </>
+            ) : (
+                <p>No data yet.</p>
+            )}
         </>
     );
 }

--- a/country-stats-app/src/SearchBox.jsx
+++ b/country-stats-app/src/SearchBox.jsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from "react";
+
+export function SearchBox({ onDataFetched }) {
+    const [search, setSearch] = useState('');
+    const handleChange = (e) => setSearch(e.target.value);
+    const [shouldFetch, setShouldFetch] = useState(false);
+
+    useEffect(() => {
+        if (!shouldFetch) return;
+
+        const fetchData = async () => {
+        try {
+            const response = await fetch(`https://restcountries.com/v3.1/name/${search}?fields=name,flags,coatOfArms`);
+            const result = await response.json();
+            if (onDataFetched) {
+                onDataFetched(result); // send data to parent
+            }
+        } catch (error) {
+            console.error('Error fetching data:', error);
+        } finally {
+            setShouldFetch(false); // reset trigger
+        }
+        };
+
+        fetchData();
+    }, [shouldFetch]);
+
+    return (
+        <>
+            <input type="text" placeholder="Enter country name here" onChange={handleChange}/>
+            <button onClick={() => setShouldFetch(true)}>Search</button>
+        </>
+    );
+}


### PR DESCRIPTION
With these updates, when the search button is pressed it will no longer display the raw data. Instead it will make a button for each of the countries returned by the API call. Pushing these buttons will bring you to the info page and pass in that country's data. (I didn't test the passing in data yet because it requires changing things on the info page, and I didn't want to mess around with that yet. Also, we might need to merge all of our branches to main in order to do it.)